### PR TITLE
feat: Make timer display editable and fix all related bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <div class="bg-white rounded-xl shadow-lg p-6 sm:p-8 text-center mb-8">
             <h1 class="text-3xl sm:text-4xl font-bold text-slate-800 mb-4">Pomodoro Timer 2.0</h1>
             <input type="text" id="goalInput" placeholder="Enter your goal for this session" required class="w-full p-3 border border-slate-300 rounded-lg mb-4 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition">
-            <div id="timer" class="text-7xl sm:text-8xl font-bold text-slate-900 my-6">25:00</div>
+            <div id="timer" contenteditable="true" class="text-7xl sm:text-8xl font-bold text-slate-900 my-6">25:00</div>
             
             <div class="flex flex-col sm:flex-row items-center justify-center gap-3">
                  <select id="durationSelect" class="w-full sm:w-auto bg-blue-500 text-white font-semibold py-3 px-4 rounded-lg cursor-pointer hover:bg-blue-600 transition appearance-none text-center">

--- a/js/main.js
+++ b/js/main.js
@@ -269,7 +269,6 @@ function resetTimer() {
     clearTimeout(timeoutId);
     cancelAnimationFrame(animationFrameId);
 
-    duration = parseInt(durationSelect.value) * 60;
     timeLeft = duration;
     updateDisplay();
 
@@ -324,6 +323,36 @@ function endSession(isFinished = false) {
          goalInput.disabled = false;
      }
 }
+
+/**
+ * Parses the user-edited time from the timer display and updates the state.
+ * @param {Event} e - The blur event from the contenteditable timer div.
+ */
+function handleTimeEdit(e) {
+    if (isRunning) {
+        updateDisplay();
+        return;
+    }
+
+    const newTime = e.target.textContent;
+    const timeParts = newTime.match(/^(\d+):([0-5]?\d)$/);
+
+    if (timeParts) {
+        const minutes = parseInt(timeParts[1], 10);
+        const seconds = parseInt(timeParts[2], 10);
+        const newTotalSeconds = (minutes * 60) + seconds;
+
+        if (newTotalSeconds > 0) {
+            timeLeft = newTotalSeconds;
+            duration = newTotalSeconds;
+            // Deselect the dropdown to avoid confusion
+            durationSelect.selectedIndex = -1;
+        }
+    }
+    // If input is invalid, revert to the last valid time by re-running updateDisplay
+    updateDisplay();
+}
+
 
 /**
  * Renders the session data into the log table.
@@ -447,6 +476,18 @@ function clearAllSessions() {
 }
 
 // --- EVENT LISTENERS ---
+timerDisplay.addEventListener('blur', handleTimeEdit);
+timerDisplay.addEventListener('keydown', (e) => {
+    // When the user presses Enter, treat it as a "blur" to save the time.
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        e.target.blur();
+    }
+    // Prevent newline characters from being inserted.
+    if (e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+    }
+});
 startBtn.addEventListener('click', startTimer);
 resetBtn.addEventListener('click', () => {
      if (currentSession) endSession();


### PR DESCRIPTION
This change allows the user to set a custom time by directly editing the main timer display. It also fixes bugs where the custom time would be overwritten by the duration dropdown's value when the timer was started or reset.

- The `contenteditable="true"` attribute has been added to the timer `div` in `index.html`.
- An event listener has been added to the timer display in `js/main.js` to parse the user's input and update the `duration` variable. This ensures the custom time is the source of truth.
- The `resetTimer` function has been modified to use the `duration` variable, preventing the custom time from being overwritten.
- The `startTimer` function now correctly uses the `timeLeft` variable, which is set by both the custom input and the dropdown, ensuring the correct time is used.
- Input validation ensures the time is in a valid `MM:SS` format.
- A `keydown` event listener handles the 'Enter' key for a better user experience.